### PR TITLE
Update README.md with organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
 
       - name: Lint Ansible Playbook
         # replace `main` with any valid ref, or tags like `v6`
-        uses: ansible/ansible-lint-action@main
+        uses: ansible-community/ansible-lint-action@main
         # optional:
         with:
           args: "" # args to pass to ansible-lint command


### PR DESCRIPTION
using the old 'ansible/ansible-lint-action' syntax in GitHub Actions (SaaS) results in an error: 'Unable to resolve actions. Repository not found : ansible/ansible-lint-action.'. This occurs despite GH redirecting properly. The proposed change executes properly.