### PR TITLE
Hint at what to actually do

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
 ```
 
 Due to limitation on how GitHub Actions are processing arguments, we do not
-plan to provide extra options. You will have to make use of [ansible-lint own configuration file](https://ansible-lint.readthedocs.io/en/latest/configuring/)
+plan to provide extra options. You will have to make use of [`.ansible-lint` (ansible-lint own configuration file)](https://ansible-lint.readthedocs.io/en/latest/configuring/)
 for altering its behavior.
 
 If you still want custom arguments, you can still fork the action and modify


### PR DESCRIPTION
I propose to add this as `.config/ansible-lint.yml` did not work, but an `.ansible-lint` in the root of the repository works right away.