### PR TITLE
Fix bug with no path arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,8 @@ inputs:
       not supported and you will need to alter linter configuration to
       accommodate other use cases.
     required: false
-    # that default just a placeholder workaround for no arguments use-case as
-    # feeding "." or empty string to ansible-lint makes it believe it is a role
+    # That default is just a placeholder workaround for no arguments use-case
+    # Feeding "." or empty string to ansible-lint makes it believe it is a role
     default: --show-relpath
   args:
     description: deprecated

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,9 @@ inputs:
       not supported and you will need to alter linter configuration to
       accommodate other use cases.
     required: false
-    default: "."
+    # that default just a placeholder workaround for no arguments use-case as
+    # feeding "." or empty string to ansible-lint makes it believe it is a role
+    default: --show-relpath
   args:
     description: deprecated
     deprecationMessage: >


### PR DESCRIPTION
Previous default value was buggy and make the linter do almost nothing as it would only assume it needs to lint a role in current directory, ignoring anything else from the repository.