### PR TITLE
Add Sarif result file support by setting an env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Container image that runs your code
+FROM quay.io/ansible/creator-ee:v0.5.2
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ jobs:
         # optional:
         # with:
         #   path: "playbooks/"  # <-- only one value is allowed
+        # env:
+        #   GITHUB_SARIF: "ansiblelint-results.sarif" # <-- if need a sarif output file
 ```
 
 Due to limitation on how GitHub Actions are processing arguments, we do not

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,7 @@ inputs:
     default: ""
 runs:
   using: docker
-  image: docker://quay.io/ansible/creator-ee:v0.5.2
-  entrypoint: /usr/local/bin/ansible-lint
+  image: Dockerfile
   env:
     # These tell ansible-lint to use github compatible annotation format:
     GITHUB_ACTIONS: "true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+
+verbosity_level="${1}"
+lintable_path="${2}"
+
+# if env variable GITHUB_SARIF is set
+# redirect the SARIF output into the file name specified by the env variable
+if [[ -z "${GITHUB_SARIF}" ]]; then
+  ansible-lint $verbosity_level $lintable_path;
+else
+  ansible-lint $verbosity_level $lintable_path -f sarif > "$GITHUB_SARIF";
+fi


### PR DESCRIPTION
As discussed in #98, this change enables the users of ansible-lint-action to be able to generate a Sarif result file by specifying an environment variable `GITHUB_SARIF` through action. The Sarif file can be used to upload to GitHub Advanced Security and show the alerts in users repository security tab.

The example action with the environment variable set:
```yaml
jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v2

      - name: Run ansible-lint
        uses: ansible-community/ansible-lint-action@main
        # optional:
        # with:
        #   path: "playbooks/"  # <-- only one value is allowed
        env:
          GITHUB_SARIF: "ansiblelint_results.sarif"
```

Tested the action in my [test workflow](https://github.com/yongyan-gh/ansiblelinttest/blob/db45e835d0f77ef52e0f56e75ff728834419ec2d/.github/workflows/sarifactiontest.yml), the result can be found at https://github.com/yongyan-gh/ansiblelinttest/actions/workflows/sarifactiontest.yml

@ssbarnea please review and let me know what you think, thanks!